### PR TITLE
fix: add secrets: inherit to run-tests-on-pr workflow

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   build:
     uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to the run-tests-on-pr reusable workflow job so repository secrets are passed through to `adobe/aio-reusable-workflows`

## Test plan
- [ ] Verify the run-tests-on-pr workflow runs successfully with secrets available

🤖 Generated with [Claude Code](https://claude.com/claude-code)